### PR TITLE
Fix typo

### DIFF
--- a/Sections/16/fund_theorem.html
+++ b/Sections/16/fund_theorem.html
@@ -33,7 +33,7 @@ In other words,
 
 $$\int\limits_C \nabla f \cdot dr = f(B) - f(A)$$
 
-This is very similar to the normal romanian integral
+This is very similar to the normal Riemannian integral
 
 $$\int\limits_a^b F'(x)dx = F(x)|_a^b = F(b) - F(a)$$
 


### PR DESCRIPTION
Fundamental Theorem of Line Integrals had a typo: romanian should be
Riemannian (or possibly just Riemann but that's a matter of taste).